### PR TITLE
Add the RBAC functionality to the K8s config

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app: news-aggregator
     spec:
+      serviceAccountName: news-aggregator-service-account
       containers:
         - name: news-aggregator
           image: alanut93/news_aggregator:1.0.15

--- a/templates/service_account.yaml
+++ b/templates/service_account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: news-aggregator-service-account
+  namespace: news-aggregator
+automountServiceAccountToken: false

--- a/templates/user_role.yaml
+++ b/templates/user_role.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: news-aggregator-role
+  namespace: news-aggregator
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services", "configmaps"]
+    verbs: ["get", "create", "delete", "patch", "list"]
+
+  - apiGroups: ["apps/v1"]
+    resources: ["deployments"]
+    verbs: ["get", "create", "delete", "patch", "list"]
+
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: news-aggregator-rolebinding
+  namespace: news-aggregator
+subjects:
+  - kind: ServiceAccount
+    name: news-aggregator-service-account
+    namespace: news-aggregator
+roleRef:
+  kind: Role
+  name: news-aggregator-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Added the service account with a limited list of permissions which are needed only for the news aggregator app.
Added and customized role and role binding.

- [x] Add the service account
- [x] Add the role and customize the permiossions
- [x] Add the Role Binding
- [x] Injected the service account to the deployment
 
Example of the Role in the Lens:
![image](https://github.com/user-attachments/assets/79a97a41-54e3-4fe8-93af-8e383506c004)

Example of the Role Binding in the Lens:
![image](https://github.com/user-attachments/assets/7089c893-fba9-4638-8edd-67347bfd3832)

Service account in the Lens:
![image](https://github.com/user-attachments/assets/f7d8bb95-e7db-420f-94aa-3f4156876f9d)
