### PR TITLE
Add config for Argocd with Apps of Apps Pattern 

### DIFF
--- a/argocd/apps/news-aggregator-app.yaml
+++ b/argocd/apps/news-aggregator-app.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: news-aggregator
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  destination:
+    name: ''
+    namespace: news-aggregator
+    server: https://kubernetes.default.svc
+  source:
+    path: news-aggregator
+    repoURL: https://github.com/ivan-poltavskiy/news-aggregator
+    targetRevision: feat/add-argocd-config
+  sources: []
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/argocd/apps/news-aggregator-app.yaml
+++ b/argocd/apps/news-aggregator-app.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     path: news-aggregator
     repoURL: https://github.com/ivan-poltavskiy/news-aggregator
-    targetRevision: feat/add-argocd-config
+    targetRevision: master
   sources: []
   project: default
   syncPolicy:

--- a/argocd/apps/news-aggregator-day0-app.yaml
+++ b/argocd/apps/news-aggregator-day0-app.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: news-aggregator-day0
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  destination:
+    name: ''
+    namespace: news-aggregator
+    server: https://kubernetes.default.svc
+  source:
+    path: aws-auth-chart
+    repoURL: https://github.com/ivan-poltavskiy/news-aggregator
+    targetRevision: feat/add-argocd-config
+    helm:
+      parameters:
+        - name: namespace
+          value: news-aggregator
+        - name: privateAccessKey
+          value:
+        - name: accessKey
+          value:
+  sources: []
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/apps/news-aggregator-day0-app.yaml
+++ b/argocd/apps/news-aggregator-day0-app.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     path: aws-auth-chart
     repoURL: https://github.com/ivan-poltavskiy/news-aggregator
-    targetRevision: feat/add-argocd-config
+    targetRevision: master
     helm:
       parameters:
         - name: namespace

--- a/argocd/apps/operator-system-app.yaml
+++ b/argocd/apps/operator-system-app.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: operator-system
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  destination:
+    name: ''
+    namespace: operator-system
+    server: https://kubernetes.default.svc
+  source:
+    path: operator/config/default
+    repoURL: https://github.com/ivan-poltavskiy/news-aggregator
+    targetRevision: feat/add-argocd-config
+  sources: []
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/argocd/apps/operator-system-app.yaml
+++ b/argocd/apps/operator-system-app.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     path: operator/config/default
     repoURL: https://github.com/ivan-poltavskiy/news-aggregator
-    targetRevision: feat/add-argocd-config
+    targetRevision: master
   sources: []
   project: default
   syncPolicy:

--- a/argocd/apps/operator-system-day0-app.yaml
+++ b/argocd/apps/operator-system-day0-app.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     path: aws-auth-chart
     repoURL: https://github.com/ivan-poltavskiy/news-aggregator
-    targetRevision: feat/add-argocd-config
+    targetRevision: master
     helm:
       parameters:
         - name: namespace

--- a/argocd/apps/operator-system-day0-app.yaml
+++ b/argocd/apps/operator-system-day0-app.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: operator-system-day0
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  destination:
+    name: ''
+    namespace: operator-system
+    server: https://kubernetes.default.svc
+  source:
+    path: aws-auth-chart
+    repoURL: https://github.com/ivan-poltavskiy/news-aggregator
+    targetRevision: feat/add-argocd-config
+    helm:
+      parameters:
+        - name: namespace
+          value: operator-system
+        - name: privateAccessKey
+          value:
+        - name: accessKey
+          value:
+  sources: []
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/news-aggregator-main-app.yaml
+++ b/argocd/news-aggregator-main-app.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     repoURL: https://github.com/ivan-poltavskiy/news-aggregator
     path: argocd/apps
-    targetRevision: feat/add-argocd-config
+    targetRevision: master
   project: default
   syncPolicy:
     automated:

--- a/argocd/news-aggregator-main-app.yaml
+++ b/argocd/news-aggregator-main-app.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: news-aggregator-apps
+  namespace: argocd
+spec:
+  destination:
+    name: ''
+    namespace: news-aggregator
+    server: https://kubernetes.default.svc
+  source:
+    repoURL: https://github.com/ivan-poltavskiy/news-aggregator
+    path: argocd/apps
+    targetRevision: feat/add-argocd-config
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
**Added 5 Argocd App manifests.** 

**Used** pattern `Apps of Apps` for more comfortable deploying this manifests. 

**First** of all, you need install the **Argo CD** to the cluster after which deploy `the news-aggregator-main-app.yaml`.

**Also** added sync-wave parameter to deploy manifests in the right order - day0 manifests are deployed first, news-aggregator is deployed second, and operator is deployed last.

**`Apps list:`**
1.  Day-0 for news-aggregator for auth to AWS.
2.  Day-0 for operator-controller for auth to AWS.
3.  News Aggregator server
4.  Operator

**`Screenshot`**:

![chrome_ZpI7NLleIW](https://github.com/user-attachments/assets/f76d6e7a-7fb1-46a7-858e-1ab21e26d4c1)

